### PR TITLE
Address the deprecation of string callbacks in 5.1

### DIFF
--- a/app/models/property_definition.rb
+++ b/app/models/property_definition.rb
@@ -19,12 +19,8 @@
 class PropertyDefinition < ActiveRecord::Base
   self.primary_key = 'property_id'
 
-  after_save :clear_caches
+  after_save { class.clear_caches }
   validate :default_value_consistent_with_type
-
-  def clear_caches
-    self.class.clear_caches
-  end
 
   def default_value_consistent_with_type
     self.class.convert_string_value(default_value, property_type)

--- a/app/models/property_definition.rb
+++ b/app/models/property_definition.rb
@@ -19,8 +19,12 @@
 class PropertyDefinition < ActiveRecord::Base
   self.primary_key = 'property_id'
 
-  after_save 'self.class.clear_caches'
+  after_save :clear_caches
   validate :default_value_consistent_with_type
+
+  def clear_caches
+    self.class.clear_caches
+  end
 
   def default_value_consistent_with_type
     self.class.convert_string_value(default_value, property_type)
@@ -175,9 +179,5 @@ class PropertyDefinition < ActiveRecord::Base
           raise "Unknown property type: #{property_type}"
       end
     end
-
   end # class << self
-
-
 end
-


### PR DESCRIPTION
The message in question:

>DEPRECATION WARNING: Passing string to define 
callback is deprecated and will be removed in 
Rails 5.1 without replacement. (called from 
<class:PropertyDefinition> at 
app/models/property_definition.rb:22)