### PR TITLE
[RETURNLY-5112/5113] Bumping Rails version dependency

### DIFF
--- a/lib/properties/version.rb
+++ b/lib/properties/version.rb
@@ -1,3 +1,3 @@
 module Properties
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/properties/version.rb
+++ b/lib/properties/version.rb
@@ -1,3 +1,3 @@
 module Properties
-  VERSION = "0.0.3"
+  VERSION = "0.1.1"
 end

--- a/lib/properties/version.rb
+++ b/lib/properties/version.rb
@@ -1,3 +1,3 @@
 module Properties
-  VERSION = "0.1.1"
+  VERSION = "0.0.3"
 end

--- a/properties.gemspec
+++ b/properties.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.2.5", "< 6.0"
+  s.add_dependency "rails", ">= 4.2.5", "< 7.0"
   s.add_dependency "composite_primary_keys"
   s.add_dependency "upsert", "~> 2.1.2"
   s.add_dependency "mysql2", ">= 0.3.13", "< 0.5"


### PR DESCRIPTION
Updating propeties gem rails version dependency to accept rails 6.0 as it is being updated in the main projects. 
Tickets for update: 
[Jira Ticket Dashboard](https://returnly.atlassian.net/secure/RapidBoard.jspa?rapidView=94&modal=detail&selectedIssue=RETURN-5112)
[Jira Ticket Returns Center](https://returnly.atlassian.net/secure/RapidBoard.jspa?rapidView=94&modal=detail&selectedIssue=RETURN-5113)